### PR TITLE
escape data-container in js

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,16 @@
         "laminas/laminas-session": "^2.8.4"
     },
     "require-dev": {
-        "laminas/laminas-developer-tools": "^1.1.0 || ^2.0",
+        "laminas/laminas-developer-tools": "^1.3.1 || ^2.0.2",
         "laminas/laminas-i18n": "^2.5",
         "laminas/laminas-log": "^2.5",
         "laminas/laminas-mvc-plugin-flashmessenger": "^1.0",
         "laminas/laminas-router": "^3.0",
         "laminas/laminas-serializer": "^2.5",
         "laminas/laminas-test": "^3.0"
+    },
+    "conflict": {
+        "laminas/laminas-developer-tools": "<1.3.1 || >=2.0 <2.0.2"
     },
     "suggest": {
         "ext-xdebug": "For better output format of session data, Xdebug should already installed",

--- a/view/laminas-developer-tools/toolbar/session-toolbar.js
+++ b/view/laminas-developer-tools/toolbar/session-toolbar.js
@@ -57,7 +57,7 @@
             var trg = e.target ? e.target : e.srcElement;
 
             var containerNameOriginal = trg.parentNode.getAttribute("data-container");
-            var containerNameEscaped  = containerNameOriginal.split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped  = escape(containerNameOriginal);
             var keysession = trg.parentNode.getAttribute("data-keysession");
             var params = "containerName="+containerNameOriginal+"&keysession="+keysession;
             sanSessionToolbar.postDataWithAjax(sanSessionToolbarURL+'/removesession', function (html) {
@@ -110,7 +110,7 @@
             e.preventDefault();
             // cross-browser event target
             var trg = e.target ? e.target : e.srcElement;
-            var containerNameEscaped = trg.parentNode.getAttribute("data-container").split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped = escape(trg.parentNode.getAttribute("data-container"));
             var keysession = trg.parentNode.getAttribute("data-keysession");
 
             doc.querySelector("#san-session-toolbar-info-containerName-"+containerNameEscaped+"-keysession-"+keysession).style.display = 'none';
@@ -123,7 +123,7 @@
             e.preventDefault();
             // cross-browser event target
             var trg = e.target ? e.target : e.srcElement;
-            var containerNameEscaped = trg.parentNode.getAttribute("data-container").split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped = escape(trg.parentNode.getAttribute("data-container"));
             var keysession = trg.parentNode.getAttribute("data-keysession");
 
             doc.querySelector("#san-session-toolbar-info-containerName-"+containerNameEscaped+"-keysession-"+keysession).style.display = 'block';
@@ -143,7 +143,7 @@
             var trg = e.target ? e.target : e.srcElement;
 
             var containerNameOriginal = trg.parentNode.getAttribute("data-container");
-            var containerNameEscaped  = containerNameOriginal.split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped  = escape(containerNameOriginal);
             var keysession = trg.parentNode.getAttribute("data-keysession");
             var params = "containerName="+containerNameOriginal+"&keysession="+keysession+"&sessionvalue="+doc.querySelector('#san-detail-value-containerName-'+containerNameEscaped+'-keysession-'+keysession).value+"&new=0";
             sanSessionToolbar.postDataWithAjax(sanSessionToolbarURL+'/savesession', function (html) {
@@ -165,7 +165,7 @@
             e.preventDefault();
             // cross-browser event target
             var trg = e.target ? e.target : e.srcElement;
-            var containerNameEscaped = trg.parentNode.getAttribute("data-container").split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped = escape(trg.parentNode.getAttribute("data-container"));
 
             doc.querySelector("#san-session-toolbar-info-add-new-data-containerName-"+containerNameEscaped).style.display = 'none';
             // empty error
@@ -178,7 +178,7 @@
             e.preventDefault();
             // cross-browser event target
             var trg = e.target ? e.target : e.srcElement;
-            var containerNameEscaped = trg.getAttribute("data-container").split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped = escape(trg.getAttribute("data-container"));
             doc.querySelector("#san-session-toolbar-info-add-new-data-containerName-"+containerNameEscaped).style.display = 'block';
         },
 
@@ -189,7 +189,7 @@
             // cross-browser event target
             var trg = e.target ? e.target : e.srcElement;
             var containerNameOriginal = trg.parentNode.getAttribute("data-container");
-            var containerNameEscaped  = containerNameOriginal.split('\\\\').join('\\\\\\\\');
+            var containerNameEscaped  = escape(containerNameOriginal);
             var newSessionKey  = doc.querySelector('#san-add-value-sessionkey-containerName-'+containerNameEscaped).value;
             var newSessionData = doc.querySelector('#san-add-value-sessiondata-containerName-'+containerNameEscaped).value;
             var params = "containerName="+containerNameOriginal+"&keysession="+newSessionKey+"&sessionvalue="+newSessionData+"&new=1";


### PR DESCRIPTION
since `laminas-developer-tools ^1.3.1 || ^2.0.2`, the content already escaped with split join, see https://github.com/laminas/laminas-developer-tools/pull/28