### PR TITLE
Fix: PHP 8.4: Implicitly nullable parameter declarations deprecated

### DIFF
--- a/src/Manager/SessionManager.php
+++ b/src/Manager/SessionManager.php
@@ -72,7 +72,7 @@ final class SessionManager implements SessionManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function sessionSetting(string $containerName, string $keysession, string $value = null, array $options = []): bool
+    public function sessionSetting(string $containerName, string $keysession, ?string $value = null, array $options = []): bool
     {
         $container = new Container($containerName);
         $new = $options['new'] ?? false;
@@ -123,7 +123,7 @@ final class SessionManager implements SessionManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function clearSession(string $byContainer = null): void
+    public function clearSession(?string $byContainer = null): void
     {
         (new Container())->getManager()
              ->getStorage()

--- a/src/Manager/SessionManagerInterface.php
+++ b/src/Manager/SessionManagerInterface.php
@@ -36,12 +36,12 @@ interface SessionManagerInterface
     /**
      * Set/Unset Session by Container and its key.
      */
-    public function sessionSetting(string $containerName, string $keysession, string $value = null, array $options = []): bool;
+    public function sessionSetting(string $containerName, string $keysession, ?string $value = null, array $options = []): bool;
 
     /**
      * Clear Session.
      *
      * @param string|null $byContainer
      */
-    public function clearSession(string $byContainer = null): void;
+    public function clearSession(?string $byContainer = null): void;
 }


### PR DESCRIPTION
In PHP 8.4 one gets an error.
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Its just an fix by marking the types nullable.